### PR TITLE
Improving performance of video inference and increase GPU utilization 4

### DIFF
--- a/wat/__init__.py
+++ b/wat/__init__.py
@@ -11,9 +11,3 @@ __all__ = [
 sys.modules['wat'] = wat  # type: ignore
 setattr(wat, '__version__', __version__)
 
-// Root Layout and Protected Routes1
-
-// Root Layout and Protected Routes1
-
-
-// Root Layout and Protected Routes4

--- a/wat/__init__.py
+++ b/wat/__init__.py
@@ -15,3 +15,5 @@ setattr(wat, '__version__', __version__)
 
 // Root Layout and Protected Routes1
 
+
+// Root Layout and Protected Routes4


### PR DESCRIPTION
This modification allowed for about three times the performance on my system with R7 5800H and RTX3060 mobile. Using the same 4k video on both resnet50 and resnet101 models, the original version ran at 2.20it/s whereas this runs at an average of 7.5it/s.