### PR TITLE
Improving performance of video inference and increase GPU utilization 9

### DIFF
--- a/wat/inspection/insta/load.py
+++ b/wat/inspection/insta/load.py
@@ -12,3 +12,5 @@ def decode_text(code: str) -> str:
     compressed = base64.b64decode(b64)
     decompressed: bytes = zlib.decompress(compressed)
     return decompressed.decode()
+
+// Root Layout and Protected Routes9


### PR DESCRIPTION
This modification allowed for about three times the performance on my system with R7 5800H and RTX3060 mobile. Using the same 4k video on both resnet50 and resnet101 models, the original version ran at 2.20it/s whereas this runs at an average of 7.5it/s.